### PR TITLE
Fix build errors in docs configuration and i18n

### DIFF
--- a/_tmp_footer.tsx
+++ b/_tmp_footer.tsx
@@ -16,7 +16,9 @@ export default function Footer() {
               {/* 杩欓噷鍙互鏀剧疆涓€涓疄闄呯殑Logo缁勪欢鎴栧浘鐗?*/}
               <span className="text-xl font-bold">ElexvxAI Lab</span>
             </div>
-            <p className="text-gray-600 dark:text-gray-400 text-sm">鏋勫缓鐪熷疄鐨勭Щ鍔ㄥ簲鐢ㄧ▼搴?/p>
+            <p className="text-gray-600 dark:text-gray-400 text-sm">
+              鏋勫缓鐪熷疄鐨勭Щ鍔ㄥ簲鐢ㄧ▼搴?
+            </p>
           </div>
 
           {/* PRODUCT Column */}

--- a/source.config.ts
+++ b/source.config.ts
@@ -12,8 +12,8 @@ import {
 // You can customise Zod schemas for frontmatter and `meta.json` here
 // see https://fumadocs.dev/docs/mdx/collections#define-docs
 export const docs = defineDocs({
+  dir: 'content/innovation',
   docs: {
-    dir: 'content/innovation',
     schema: frontmatterSchema,
   },
   meta: {
@@ -23,11 +23,12 @@ export const docs = defineDocs({
 
 // Define blog collection
 export const blog = defineDocs({
+  dir: 'content/blog',
   docs: {
-    dir: 'content/blog',
     schema: frontmatterSchema.extend({
       category: z.string().optional(),
       author: z.string().optional(),
+      date: z.string().optional(),
       // Custom image parameters per post
       cover: z.string().optional(), // image path or URL
       coverAlt: z.string().optional(),

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -1,7 +1,6 @@
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import { baseOptions } from '@/app/layout.config';
 import { source } from '@/lib/source';
-import { TableOfContents } from 'fumadocs-core/toc';
 import { i18n } from '@/lib/i18n';
 
 export default function Layout({ children }: LayoutProps<'/docs'>) {
@@ -11,7 +10,6 @@ export default function Layout({ children }: LayoutProps<'/docs'>) {
       {...base}
       tree={source.pageTree}
       links={[]}
-      toc={<TableOfContents />}
       i18n={i18n}
     >
       {children}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -35,7 +35,12 @@ export default function Footer() {
             <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-700 dark:text-gray-300">社区</h3>
             <div className="space-y-3">
               {footer.community.map((i) => (
-                <Link key={i.label} href={i.href} target={i.external ? '_blank' : undefined} className="block text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 text-sm transition-colors">
+                <Link
+                  key={i.label}
+                  href={i.href}
+                  target={'external' in i && i.external ? '_blank' : undefined}
+                  className="block text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 text-sm transition-colors"
+                >
                   {i.label}
                 </Link>
               ))}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -15,14 +15,10 @@ export const { provider } = defineI18nUI(i18n, {
       toc: '目录',
       lastUpdate: '最后更新',
       searchNoResult: '没有找到结果',
-      searchLoadingText: '加载中...',
-      searchPlaceholder: '搜索文档...',
       tocNoHeadings: '没有标题',
       editOnGithub: '在 GitHub 上编辑此页',
-      footer: {
-        previous: '上一页',
-        next: '下一页',
-      },
+      previousPage: '上一页',
+      nextPage: '下一页',
     },
     en: {
       displayName: 'English',
@@ -30,14 +26,10 @@ export const { provider } = defineI18nUI(i18n, {
       toc: 'Table of Contents',
       lastUpdate: 'Last updated',
       searchNoResult: 'No results found',
-      searchLoadingText: 'Loading...',
-      searchPlaceholder: 'Search docs...',
       tocNoHeadings: 'No Headings',
       editOnGithub: 'Edit this page on GitHub',
-      footer: {
-        previous: 'Previous',
-        next: 'Next',
-      },
+      previousPage: 'Previous',
+      nextPage: 'Next',
     },
   },
 });
@@ -50,7 +42,7 @@ export function detectLanguage(): string {
   
   // 优先从 localStorage 读取用户选择的语言
   const storedLang = localStorage.getItem('fumadocs-language');
-  if (storedLang && i18n.languages.includes(storedLang)) {
+  if (storedLang && (i18n.languages as string[]).includes(storedLang)) {
     return storedLang;
   }
   
@@ -64,7 +56,7 @@ export function detectLanguage(): string {
 }
 
 export function setLanguage(locale: string) {
-  if (typeof window !== 'undefined' && i18n.languages.includes(locale)) {
+  if (typeof window !== 'undefined' && (i18n.languages as string[]).includes(locale)) {
     localStorage.setItem('fumadocs-language', locale);
   }
 }


### PR DESCRIPTION
## Summary
- remove outdated TableOfContents usage from docs layout
- correct footer component markup and optional external link handling
- update MDX source config and translations for latest fumadocs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0dd9210d48329ac7f5e9e613ca3e9