### PR TITLE
feat: redesign homepage with gradient animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "feed": "^5.1.0",
+        "framer-motion": "^12.23.12",
         "fumadocs-core": "15.7.3",
         "fumadocs-mdx": "11.8.1",
         "fumadocs-twoslash": "^3.1.7",
@@ -4091,6 +4092,33 @@
         "pnpm": ">=10"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fumadocs-core": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-15.7.3.tgz",
@@ -6198,6 +6226,21 @@
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "feed": "^5.1.0",
+    "framer-motion": "^12.23.12",
     "fumadocs-core": "15.7.3",
     "fumadocs-mdx": "11.8.1",
     "fumadocs-twoslash": "^3.1.7",

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,27 +1,91 @@
+'use client';
+
 import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { ThemeToggle } from '@/components/theme-toggle';
+
+const navItems = [
+  { href: '/docs', title: '文档', desc: '开始上手与深入指南' },
+  { href: '/blog', title: '博客', desc: '更新、洞见与最佳实践' },
+  { href: '/sponsors', title: '赞助商', desc: '支持我们，推动社区发展' },
+];
 
 export default function HomePage() {
+  const fadeIn = {
+    initial: { opacity: 0, y: 20 },
+    whileInView: { opacity: 1, y: 0 },
+    viewport: { once: true },
+  };
+
   return (
-    <main className="flex flex-1 flex-col justify-center gap-10">
-      <section className="text-center">
-        <h1 className="mb-4 text-3xl font-bold">构建你的文档站</h1>
-        <p className="text-fd-muted-foreground">使用 Fumadocs 打造优雅、强大的文档体验。</p>
+    <main className="flex flex-col flex-1">
+      {/* Hero Section */}
+      <section className="relative flex flex-col items-center justify-center text-center py-24 overflow-hidden">
+        <div className="absolute inset-0 -z-10 bg-gradient-to-b from-purple-100 via-white to-white dark:from-gray-900 dark:via-gray-900 dark:to-gray-800" />
+        <ThemeToggle className="absolute right-4 top-4" />
+        <motion.h1
+          {...fadeIn}
+          className="text-5xl md:text-6xl font-bold bg-gradient-to-r from-fuchsia-600 via-pink-500 to-orange-400 bg-clip-text text-transparent animate-gradient-x"
+        >
+          AI 实验室文档站
+        </motion.h1>
+        <motion.p
+          {...fadeIn}
+          transition={{ delay: 0.2 }}
+          className="mt-6 max-w-2xl text-lg text-fd-muted-foreground"
+        >
+          使用 Fumadocs 打造优雅、强大的文档体验。
+        </motion.p>
       </section>
 
-      <nav className="container grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <Link href="/docs" className="rounded-xl border p-6 hover:bg-fd-card transition">
-          <h3 className="text-lg font-semibold mb-1">文档</h3>
-          <p className="text-sm text-fd-muted-foreground">开始上手与深入指南</p>
-        </Link>
-        <Link href="/blog" className="rounded-xl border p-6 hover:bg-fd-card transition">
-          <h3 className="text-lg font-semibold mb-1">博客</h3>
-          <p className="text-sm text-fd-muted-foreground">更新、洞见与最佳实践</p>
-        </Link>
-        <Link href="/sponsors" className="rounded-xl border p-6 hover:bg-fd-card transition">
-          <h3 className="text-lg font-semibold mb-1">赞助商</h3>
-          <p className="text-sm text-fd-muted-foreground">支持我们，推动社区发展</p>
-        </Link>
-      </nav>
+      {/* Navigation Cards */}
+      <section className="container mx-auto px-4 py-16 space-y-12">
+        <motion.nav {...fadeIn} className="grid gap-6 sm:grid-cols-3">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="group rounded-xl border bg-background overflow-hidden hover:shadow-lg transition-shadow"
+            >
+              <div className="p-6">
+                <h3 className="text-lg font-semibold bg-gradient-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent mb-2 transition-all group-hover:from-pink-500 group-hover:to-purple-500">
+                  {item.title}
+                </h3>
+                <p className="text-sm text-fd-muted-foreground transition-colors group-hover:text-foreground">
+                  {item.desc}
+                </p>
+              </div>
+            </Link>
+          ))}
+        </motion.nav>
+
+        {/* Case Section with Images */}
+        <motion.div {...fadeIn} className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3].map((id) => (
+            <div
+              key={id}
+              className="group rounded-xl border bg-background overflow-hidden hover:shadow-lg transition-shadow"
+            >
+              <div className="relative aspect-[16/9] overflow-hidden">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={`https://picsum.photos/600/400?random=${id}`}
+                  alt={`case ${id}`}
+                  className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                />
+              </div>
+              <div className="p-5">
+                <h3 className="text-lg font-semibold mb-2 transition-colors group-hover:text-fd-primary">
+                  案例标题 {id}
+                </h3>
+                <p className="text-sm text-fd-muted-foreground transition-colors group-hover:text-foreground">
+                  案例文案，支持后期替换。
+                </p>
+              </div>
+            </div>
+          ))}
+        </motion.div>
+      </section>
     </main>
   );
 }

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -92,3 +92,12 @@ nav[aria-label="目录"] a[data-active="true"] {
   color: var(--_toc-accent);
   font-weight: 600;
 }
+@keyframes gradient-x {
+  0%,100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}
+
+.animate-gradient-x {
+  background-size: 200% 200%;
+  animation: gradient-x 6s ease infinite;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,10 @@ export default function Layout({ children }: LayoutProps) {
         <Banner id="welcome-banner" variant="rainbow">
           🎉 欢迎来到文档站！探索技术文档与示例代码。
         </Banner>
-        <RootProvider i18n={{ locale: 'zh', locales, translations: zh }}>
+        <RootProvider
+          i18n={{ locale: 'zh', locales, translations: zh }}
+          theme={{ defaultTheme: 'light', attribute: 'class' }}
+        >
           {children}
         </RootProvider>
         {/* Vercel Analytics & Speed Insights */}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,32 +1,33 @@
 export function Footer() {
+  const columns = [
+    { title: '产品', links: ['文档', '博客', '赞助商'] },
+    { title: '资源', links: ['API', '示例', '教程'] },
+    { title: '社区', links: ['GitHub', 'Discord', 'Twitter'] },
+    { title: '公司', links: ['关于我们', '隐私政策', '联系我们'] },
+  ];
+
   return (
     <footer className="mt-16">
-      {/* 信息区 */}
       <div className="border-t bg-background/50">
-        <div className="container mx-auto px-4 py-10 text-sm text-fd-muted-foreground grid gap-6 sm:grid-cols-3">
-          <div className="space-y-2">
-            <div className="font-semibold text-foreground">ElexvxAI Lab</div>
-            <p className="leading-6">以工程化与产品思维打造更好的开发者体验。</p>
-          </div>
-          <div>
-            <div className="font-medium mb-3 text-foreground">链接</div>
-            <ul className="space-y-2">
-              <li><a className="hover:underline" href="/docs">文档</a></li>
-              <li><a className="hover:underline" href="/blog">博客</a></li>
-              <li><a className="hover:underline" href="/sponsors">赞助商</a></li>
-            </ul>
-          </div>
-          <div>
-            <div className="font-medium mb-3 text-foreground">链接</div>
-            <ul className="space-y-2">
-              <li><a className="hover:underline" href="/docs">文档</a></li>
-              <li><a className="hover:underline" href="/blog">博客</a></li>
-              <li><a className="hover:underline" href="/sponsors">赞助商</a></li>
-            </ul>
+        <div className="container mx-auto px-4 py-10 text-sm text-fd-muted-foreground">
+          <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-4">
+            {columns.map((col) => (
+              <div key={col.title}>
+                <div className="font-medium mb-3 text-foreground">{col.title}</div>
+                <ul className="space-y-2">
+                  {col.links.map((link) => (
+                    <li key={link}>
+                      <a href="#" className="hover:underline">
+                        {link}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
           </div>
         </div>
       </div>
-      {/* 版权区：单独一行置底 */}
       <div className="border-t bg-background">
         <div className="container mx-auto px-4 py-6 text-xs text-center text-fd-muted-foreground">
           © {new Date().getFullYear()} Elexvx. All rights reserved.

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import { cn } from '@/lib/cn';
+
+interface ThemeToggleProps {
+  className?: string;
+}
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
+  const isLight = theme === 'light';
+  return (
+    <motion.button
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.95 }}
+      className={cn(
+        'p-2 rounded-full shadow bg-gradient-to-r from-yellow-400 via-pink-500 to-purple-600 text-white transition-colors',
+        className,
+      )}
+      onClick={() => setTheme(isLight ? 'dark' : 'light')}
+      aria-label="Toggle theme"
+    >
+      {isLight ? '🌙' : '☀️'}
+    </motion.button>
+  );
+}


### PR DESCRIPTION
## Summary
- redesign landing page with gradient hero, animated cards, and example case section
- add theme toggle and light default theme support
- revamp footer into responsive multi-column layout
- include framer-motion for scroll and hover animations

## Testing
- `npm run build`
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_68b22e60af44832991e5b90d06906a05