### PR TITLE
Fix blog cover image paths

### DIFF
--- a/src/app/api/blog/latest/route.ts
+++ b/src/app/api/blog/latest/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { blog } from '@/lib/source';
+import { normalizeImageSrc } from '@/lib/normalize-image-src';
 
 export const dynamic = 'force-static';
 
@@ -24,7 +25,7 @@ export async function GET() {
         title: p.data.title as string,
         description: p.data.description as string | undefined,
         url: p.url,
-        cover: data.cover as string | undefined,
+        cover: normalizeImageSrc(data.cover as string | undefined),
         author: data.author as string | undefined,
         date: data.date ? new Date(data.date).toISOString() : undefined,
         _dateNum: parseDate(data.date),

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { blog } from '@/lib/source';
+import { normalizeImageSrc } from '@/lib/normalize-image-src';
 
 function parseDate(d: unknown): number {
   if (!d) return 0;
@@ -25,7 +26,7 @@ export default function BlogIndexPage() {
 
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {posts.map((post) => {
-          const cover = (post.data as any).cover as string | undefined;
+          const cover = normalizeImageSrc((post.data as any).cover as string | undefined);
           const author = (post.data as any).author as string | undefined;
           const date = (post.data as any).date as string | Date | undefined;
           return (
@@ -36,8 +37,8 @@ export default function BlogIndexPage() {
             >
               {cover ? (
                 <div className="relative aspect-[16/9]">
-                  <Image 
-                    src={cover} 
+                  <Image
+                    src={cover}
                     alt={post.data.title} 
                     fill
                     className="object-cover" 

--- a/src/lib/normalize-image-src.ts
+++ b/src/lib/normalize-image-src.ts
@@ -1,0 +1,24 @@
+const ABSOLUTE_PATTERN = /^(?:[a-z][a-z\d+\-.]*:|\/\/)/i;
+const DUMMY_BASE = 'https://dummy.invalid';
+const DUMMY_BASE_WITH_SLASH = `${DUMMY_BASE}/`;
+
+export function normalizeImageSrc(value?: string): string | undefined {
+  if (!value) return undefined;
+
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  if (ABSOLUTE_PATTERN.test(trimmed) || trimmed.startsWith('/')) {
+    return trimmed;
+  }
+
+  try {
+    const url = new URL(trimmed, DUMMY_BASE_WITH_SLASH);
+    if (url.origin === DUMMY_BASE) {
+      return url.pathname;
+    }
+    return trimmed;
+  } catch {
+    return trimmed;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared normalizeImageSrc helper to resolve relative image paths
- use the helper when rendering the blog index and returning the latest posts API so cover images work with MDX frontmatter

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3cfab1ea8832980a5ed8443f81b43